### PR TITLE
refactor: use ioredis client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,6 +365,9 @@ $RECYCLE.BIN/
 # Antelope
 .antelope
 
+# AntelopeJS / build caches
+node-compile-cache
+
 # pnpm store
 .pnpm-store
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ The Redis module can be configured with standard Redis client options:
 ```json
 {
   "url": "redis://localhost:6379",
-  "socket": {
-    "reconnectStrategy": true
-  }
+  "lazyConnect": true
 }
 ```
 
@@ -55,7 +53,7 @@ The Redis module can be configured with standard Redis client options:
 
 The module accepts the following configuration properties:
 
-- All standard Redis client options from the `redis` package
+- All standard Redis client options from the `ioredis` package
 - Supports all connection methods including URL string, socket options, etc.
 
 ## Integration with Other Modules

--- a/output/redis/beta/index.d.ts
+++ b/output/redis/beta/index.d.ts
@@ -1,4 +1,4 @@
-import { RedisClientType } from 'redis';
+import Redis from 'ioredis';
 /**
  * Retrieves the initialized Redis client instance.
  * This is the main entry point for accessing Redis functionality.
@@ -26,4 +26,4 @@ import { RedisClientType } from 'redis';
  * }
  * ```
  */
-export declare function GetClient(): Promise<RedisClientType>;
+export declare function GetClient(): Promise<Redis>;

--- a/package.json
+++ b/package.json
@@ -46,14 +46,13 @@
     }
   },
   "dependencies": {
-    "redis": "^4.7.0"
+    "ioredis": "^5.4.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "rimraf": "^6.0.1",
     "@eslint/js": "^9.25.0",
     "@types/node": "^22.14.1",
-    "@types/redis": "^4.0.11",
     "eslint": "^9.25.0",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-import": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      redis:
-        specifier: ^4.7.0
-        version: 4.7.0
+      ioredis:
+        specifier: ^5.4.2
+        version: 5.9.2
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -21,9 +21,6 @@ importers:
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
-      '@types/redis':
-        specifier: ^4.0.11
-        version: 4.0.11
       eslint:
         specifier: ^9.25.0
         version: 9.25.1(jiti@2.5.1)
@@ -251,6 +248,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -340,35 +340,6 @@ packages:
     resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@redis/bloom@1.2.0':
-    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/client@1.6.0':
-    resolution: {integrity: sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==}
-    engines: {node: '>=14'}
-
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -393,10 +364,6 @@ packages:
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
-
-  '@types/redis@4.0.11':
-    resolution: {integrity: sha512-bI+gth8La8Wg/QCR1+V1fhrL9+LZUSWfcqpOj2Kc80ZQ4ffbdL173vQd5wovmoV9i071FU9oP2g6etLuEwb6Rg==}
-    deprecated: This is a stub types definition. redis provides its own type definitions, so you do not need this installed.
 
   '@typescript-eslint/eslint-plugin@8.31.0':
     resolution: {integrity: sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==}
@@ -732,6 +699,10 @@ packages:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -978,10 +949,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  generic-pool@3.9.0:
-    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
-    engines: {node: '>= 4'}
-
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
@@ -1118,6 +1085,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ioredis@5.9.2:
+    resolution: {integrity: sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==}
+    engines: {node: '>=12.22.0'}
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -1316,12 +1287,18 @@ packages:
   lodash.capitalize@4.2.1:
     resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -1656,8 +1633,13 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  redis@4.7.0:
-    resolution: {integrity: sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==}
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1806,6 +1788,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -1868,6 +1853,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -2197,6 +2183,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
 
+  '@ioredis/commands@1.5.0': {}
+
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.0':
@@ -2291,32 +2279,6 @@ snapshots:
 
   '@pkgr/core@0.2.4': {}
 
-  '@redis/bloom@1.2.0(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/client@1.6.0':
-    dependencies:
-      cluster-key-slot: 1.1.2
-      generic-pool: 3.9.0
-      yallist: 4.0.0
-
-  '@redis/graph@1.1.1(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/json@1.0.7(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/search@1.2.0(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/time-series@1.1.0(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
   '@rtsao/scc@1.1.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
@@ -2338,10 +2300,6 @@ snapshots:
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
-
-  '@types/redis@4.0.11':
-    dependencies:
-      redis: 4.7.0
 
   '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.5.1))(typescript@5.8.3))(eslint@9.25.1(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
@@ -2737,6 +2695,8 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  denque@2.1.0: {}
+
   destr@2.0.5: {}
 
   doctrine@2.1.0:
@@ -3067,8 +3027,6 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  generic-pool@3.9.0: {}
-
   get-east-asian-width@1.3.0: {}
 
   get-intrinsic@1.3.0:
@@ -3228,6 +3186,20 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ioredis@5.9.2:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.0
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ip-address@9.0.5:
     dependencies:
@@ -3417,9 +3389,13 @@ snapshots:
 
   lodash.capitalize@4.2.1: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.escaperegexp@4.1.2: {}
 
   lodash.get@4.4.2: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -3752,14 +3728,11 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  redis@4.7.0:
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
     dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.0)
-      '@redis/client': 1.6.0
-      '@redis/graph': 1.1.1(@redis/client@1.6.0)
-      '@redis/json': 1.0.7(@redis/client@1.6.0)
-      '@redis/search': 1.2.0(@redis/client@1.6.0)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.0)
+      redis-errors: 1.2.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3963,6 +3936,8 @@ snapshots:
     optional: true
 
   sprintf-js@1.1.3: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,35 @@
 import { internal } from '@ajs.local/redis/beta';
-import { createClient, RedisClientOptions, RedisClientType } from 'redis';
+import Redis, { RedisOptions } from 'ioredis';
 
-let redisConfig: RedisClientOptions;
-export function construct(config: RedisClientOptions): void {
+export interface RedisConfig extends RedisOptions {
+  url?: string;
+}
+
+let redisConfig: RedisConfig;
+export function construct(config: RedisConfig): void {
   redisConfig = config;
 }
 
 export function destroy(): void {}
 
 export function start(): void {
-  const client = createClient(redisConfig) as RedisClientType;
-  void client.connect();
+  const client = createRedisClient(redisConfig);
   internal.SetClient(client);
 }
 
 export async function stop(): Promise<void> {
   const client = await internal.client;
-  await client.disconnect();
+  await client.quit();
   void internal.UnsetClient();
+}
+
+function createRedisClient(config: RedisConfig): Redis {
+  const { url, ...options } = config;
+  if (!url) {
+    return new Redis(options);
+  }
+  if (Object.keys(options).length === 0) {
+    return new Redis(url);
+  }
+  return new Redis(url, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,11 @@ export function construct(config: RedisConfig): void {
 
 export function destroy(): void {}
 
-export function start(): void {
+export async function start(): Promise<void> {
   const client = createRedisClient(redisConfig);
+  if (redisConfig.lazyConnect) {
+    await client.connect();
+  }
   internal.SetClient(client);
 }
 

--- a/src/interfaces/redis/beta/index.ts
+++ b/src/interfaces/redis/beta/index.ts
@@ -1,11 +1,11 @@
-import { RedisClientType } from 'redis';
+import Redis from 'ioredis';
 
 /**
  * @internal
  */
 export namespace internal {
-  export let client: Promise<RedisClientType>;
-  export let SetClient: (client: RedisClientType) => void;
+  export let client: Promise<Redis>;
+  export let SetClient: (client: Redis) => void;
   export const UnsetClient = () => (client = new Promise((resolve) => (SetClient = resolve)));
   void UnsetClient();
 }
@@ -37,6 +37,6 @@ export namespace internal {
  * }
  * ```
  */
-export function GetClient(): Promise<RedisClientType> {
+export function GetClient(): Promise<Redis> {
   return internal.client;
 }

--- a/src/interfaces/redis_scheduler/beta.ts
+++ b/src/interfaces/redis_scheduler/beta.ts
@@ -239,7 +239,7 @@ export async function updateTimer() {
 export async function runTasks() {
   locked = true;
   const client = await GetClient();
-  const tasks = await client.zrange(RedisKey, Date.now(), 0, 'BYSCORE', 'REV');
+  const tasks = await client.zrangebyscore(RedisKey, 0, Date.now());
   if (tasks.length > 0) {
     await client.zrem(RedisKey, ...tasks);
     for (const task of tasks) {

--- a/src/interfaces/redis_scheduler/beta.ts
+++ b/src/interfaces/redis_scheduler/beta.ts
@@ -64,6 +64,10 @@ const SubscriberMessageHandlers: Record<string, () => void> = {
   [SchedulerUpdateMessage]: () => void updateTimer(),
 };
 
+function createTaskMember(handlerName: string, taskInfo: string): string {
+  return handlerName + ':' + taskInfo;
+}
+
 /**
  * Enables the task execution listener
  * This starts monitoring for scheduled tasks and executes them when due
@@ -156,7 +160,7 @@ export async function addTask(handlerName: string, dueTime: number, taskInfo: st
   }
 
   const client = await GetClient();
-  await client.zadd(RedisKey, dueTime, handlerName + ':' + taskInfo);
+  await client.zadd(RedisKey, dueTime, createTaskMember(handlerName, taskInfo));
   if (!locked) {
     void client.publish(SchedulerChannel, SchedulerUpdateMessage);
   }
@@ -191,7 +195,7 @@ export async function removeTask(handlerName: string, taskInfo: string) {
     throw new Error('Unknown SchedulerUtil handler: ' + handlerName);
   }
   const client = await GetClient();
-  await client.zrem(RedisKey, taskInfo);
+  await client.zrem(RedisKey, createTaskMember(handlerName, taskInfo));
 }
 
 /** Flag to prevent concurrent task execution */

--- a/src/interfaces/redis_scheduler/beta.ts
+++ b/src/interfaces/redis_scheduler/beta.ts
@@ -1,6 +1,6 @@
 import { RegisteringProxy } from '@ajs/core/beta';
 import { GetClient } from '@ajs.local/redis/beta';
-import { RedisClientType } from 'redis';
+import Redis from 'ioredis';
 
 /**
  * Handler function type for processing scheduled tasks
@@ -10,6 +10,12 @@ type HandlerType = (taskInfo: string) => void | Promise<void>;
 
 /** Redis key used to store scheduled tasks in a sorted set */
 const RedisKey = 'SchedulerUtil.Tasks';
+const SchedulerChannel = 'SchedulerUtil';
+const SchedulerUpdateMessage = 'update';
+const MaxRetries = 3;
+const RetryDelayMs = 5000;
+const MaxTimerDelayMs = 86400000;
+const RetryPattern = /^(?:RETRY-(\d)+:)?([^:]*):(.*)$/;
 
 /** Map of registered task handlers by name */
 const handlers = new Map<string, HandlerType>();
@@ -51,7 +57,11 @@ export function setHandler(handlerName: string, handler: HandlerType) {
 }
 
 /** Redis subscriber client for receiving task updates */
-let subscriber: RedisClientType;
+let subscriber: Redis;
+
+const SubscriberMessageHandlers: Record<string, () => void> = {
+  [SchedulerUpdateMessage]: () => void updateTimer(),
+};
 
 /**
  * Enables the task execution listener
@@ -74,16 +84,16 @@ let subscriber: RedisClientType;
  */
 export async function enableListener() {
   subscriber = (await GetClient()).duplicate();
-  await subscriber.connect();
-
-  await subscriber.subscribe('SchedulerUtil', (message, channel) => {
-    if (channel === 'SchedulerUtil') {
-      switch (message) {
-        case 'update':
-          void updateTimer();
-          break;
-      }
+  await subscriber.subscribe(SchedulerChannel);
+  subscriber.on('message', (channel, message) => {
+    if (channel !== SchedulerChannel) {
+      return;
     }
+    const handler = SubscriberMessageHandlers[message];
+    if (!handler) {
+      return;
+    }
+    handler();
   });
 
   void updateTimer();
@@ -105,7 +115,7 @@ export async function enableListener() {
  * ```
  */
 export async function disableListener() {
-  await subscriber.disconnect();
+  await subscriber.quit();
 }
 
 /**
@@ -142,9 +152,9 @@ export async function addTask(handlerName: string, dueTime: number, taskInfo: st
   }
 
   const client = await GetClient();
-  await client.zAdd(RedisKey, { score: dueTime, value: handlerName + ':' + taskInfo });
+  await client.zadd(RedisKey, dueTime, handlerName + ':' + taskInfo);
   if (!locked) {
-    void client.publish('SchedulerUtil', 'update');
+    void client.publish(SchedulerChannel, SchedulerUpdateMessage);
   }
 }
 
@@ -177,7 +187,7 @@ export async function removeTask(handlerName: string, taskInfo: string) {
     throw new Error('Unknown SchedulerUtil handler: ' + handlerName);
   }
   const client = await GetClient();
-  await client.zRem(RedisKey, taskInfo);
+  await client.zrem(RedisKey, taskInfo);
 }
 
 /** Flag to prevent concurrent task execution */
@@ -195,16 +205,20 @@ export async function updateTimer() {
   }
 
   const client = await GetClient();
-  const taskInfo = (await client.zRange(RedisKey, 0, 0))[0];
+  const taskInfo = (await client.zrange(RedisKey, 0, 0))[0];
   if (taskInfo) {
-    const score = (await client.zScore(RedisKey, taskInfo))!;
+    const scoreValue = await client.zscore(RedisKey, taskInfo);
+    if (!scoreValue) {
+      return;
+    }
+    const score = Number(scoreValue);
     if (score < Date.now()) {
       await runTasks();
     } else {
       if (timer) {
         clearTimeout(timer);
       }
-      timer = setTimeout(() => void runTasks(), Math.min(score - Date.now(), 86400000));
+      timer = setTimeout(() => void runTasks(), Math.min(score - Date.now(), MaxTimerDelayMs));
     }
   }
 }
@@ -217,11 +231,11 @@ export async function updateTimer() {
 export async function runTasks() {
   locked = true;
   const client = await GetClient();
-  const tasks = await client.zRange(RedisKey, Date.now(), 0, { REV: true, BY: 'SCORE' });
+  const tasks = await client.zrange(RedisKey, Date.now(), 0, 'BYSCORE', 'REV');
   if (tasks.length > 0) {
-    await client.zRem(RedisKey, tasks);
+    await client.zrem(RedisKey, ...tasks);
     for (const task of tasks) {
-      const m = task.match(/^(?:RETRY-(\d)+:)?([^:]*):(.*)$/);
+      const m = task.match(RetryPattern);
       try {
         if (m && handlers.has(m[2])) {
           await handlers.get(m[2])!(m[3]);
@@ -229,12 +243,9 @@ export async function runTasks() {
       } catch (err) {
         console.error(err);
         if (m) {
-          const retryCount = m[1] ? parseInt(m[1]) : 0;
-          if (retryCount < 3) {
-            await client.zAdd(RedisKey, {
-              score: Date.now() + 5000,
-              value: `RETRY-${retryCount + 1}:${m[2]}:${m[3]}`,
-            });
+          const retryCount = m[1] ? parseInt(m[1], 10) : 0;
+          if (retryCount < MaxRetries) {
+            await client.zadd(RedisKey, Date.now() + RetryDelayMs, `RETRY-${retryCount + 1}:${m[2]}:${m[3]}`);
           }
         }
       }

--- a/src/interfaces/redis_scheduler/beta.ts
+++ b/src/interfaces/redis_scheduler/beta.ts
@@ -16,6 +16,7 @@ const MaxRetries = 3;
 const RetryDelayMs = 5000;
 const MaxTimerDelayMs = 86400000;
 const RetryPattern = /^(?:RETRY-(\d)+:)?([^:]*):(.*)$/;
+const RedisReadyStatus = 'ready';
 
 /** Map of registered task handlers by name */
 const handlers = new Map<string, HandlerType>();
@@ -84,6 +85,9 @@ const SubscriberMessageHandlers: Record<string, () => void> = {
  */
 export async function enableListener() {
   subscriber = (await GetClient()).duplicate();
+  if (subscriber.status !== RedisReadyStatus) {
+    await subscriber.connect();
+  }
   await subscriber.subscribe(SchedulerChannel);
   subscriber.on('message', (channel, message) => {
     if (channel !== SchedulerChannel) {


### PR DESCRIPTION
Migrates this module from the node-redis client to ioredis.

Changes:
- Switch Redis bootstrap/client wiring to ioredis
- Update scheduler implementation to ioredis commands
- Update docs + generated exports

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully migrates the Redis client library from `node-redis` to `ioredis`, updating all API calls and connection handling accordingly.

**Key changes:**
- Replaced `node-redis` package with `ioredis` in dependencies
- Updated client initialization to use `ioredis` constructor patterns (handles URL and options separately)
- Migrated Redis commands to `ioredis` syntax (`zadd`, `zrem`, `zrange`, `zrangebyscore`, `zscore`, `publish`)
- Changed connection/disconnection methods (`connect()` for lazy connections, `quit()` instead of `disconnect()`)
- Fixed subscriber setup to properly handle connection state before subscribing
- Improved code quality by extracting magic values to named constants (`MaxRetries`, `RetryDelayMs`, `MaxTimerDelayMs`, etc.)
- Replaced inline subscriber message handling with object-based dispatch pattern (adheres to `AGENTS.md` guidelines)

**Previous issues addressed:**
All four issues from previous review threads have been correctly fixed through subsequent commits, including proper task member ID construction, correct use of `zrangebyscore` for score-based queries, subscriber connection awaiting, and lazy connection handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The migration from `node-redis` to `ioredis` is complete and correctly implemented. All previously identified issues have been fixed through follow-up commits. The code adheres to the repository's style guidelines (extracted constants, no switch/case, object-based handlers). All Redis commands use correct `ioredis` syntax, connection handling is proper (including lazy connection and subscriber duplication), and graceful shutdown uses `quit()` instead of `disconnect()`. The changes are well-structured with appropriate function decomposition and error handling.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/index.ts | migrated to `ioredis` constructor, added `lazyConnect` handling, changed disconnect to quit |
| src/interfaces/redis/beta/index.ts | updated type from `RedisClientType` to `Redis` from `ioredis` |
| src/interfaces/redis_scheduler/beta.ts | migrated Redis commands to `ioredis` syntax, extracted magic values to constants, fixed subscriber connection handling |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant Module as Redis Module
    participant Client as ioredis Client
    participant Scheduler as Redis Scheduler
    participant Subscriber as ioredis Subscriber
    participant RedisDB as Redis Server

    Note over App,RedisDB: Initialization Flow
    App->>Module: construct(config)
    App->>Module: start()
    Module->>Client: new Redis(url, options)
    alt lazyConnect is true
        Module->>Client: await connect()
        Client->>RedisDB: establish connection
    end
    Module->>Module: SetClient(client)

    Note over App,RedisDB: Scheduler Setup
    App->>Scheduler: setHandler(handlerName, handler)
    Scheduler->>Scheduler: store handler in Map
    App->>Scheduler: enableListener()
    Scheduler->>Client: duplicate()
    Client-->>Subscriber: new client instance
    alt subscriber not ready
        Scheduler->>Subscriber: await connect()
    end
    Scheduler->>Subscriber: subscribe(SchedulerChannel)
    Subscriber->>RedisDB: SUBSCRIBE SchedulerUtil
    Scheduler->>Scheduler: updateTimer()

    Note over App,RedisDB: Task Scheduling
    App->>Scheduler: addTask(handlerName, dueTime, taskInfo)
    Scheduler->>Client: zadd(RedisKey, dueTime, member)
    Client->>RedisDB: ZADD SchedulerUtil.Tasks
    alt not locked
        Scheduler->>Client: publish(SchedulerChannel, update)
        Client->>RedisDB: PUBLISH SchedulerUtil update
        RedisDB->>Subscriber: message received
        Subscriber->>Scheduler: trigger updateTimer()
    end

    Note over App,RedisDB: Task Execution
    Scheduler->>Client: zrangebyscore(RedisKey, 0, now)
    Client->>RedisDB: ZRANGEBYSCORE SchedulerUtil.Tasks
    RedisDB-->>Client: due tasks list
    Client-->>Scheduler: tasks[]
    Scheduler->>Client: zrem(RedisKey, ...tasks)
    loop for each task
        Scheduler->>Scheduler: execute handler(taskInfo)
        alt handler fails
            Scheduler->>Client: zadd(RedisKey, retryTime, retryTask)
        end
    end
    Scheduler->>Scheduler: updateTimer()

    Note over App,RedisDB: Shutdown Flow
    App->>Scheduler: disableListener()
    Scheduler->>Subscriber: quit()
    Subscriber->>RedisDB: graceful disconnect
    App->>Module: stop()
    Module->>Client: quit()
    Client->>RedisDB: graceful disconnect
    Module->>Module: UnsetClient()
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->