### PR TITLE
test: add interface tests with ioredis-mock support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,7 +37,7 @@ export default tseslint.config(
       parserOptions: {
         project: ['tsconfig.json'],
         projectService: {
-          allowDefaultProject: ['*.ts', 'eslint.config.mjs'],
+          allowDefaultProject: ['*.ts', '*.js', 'src/test/*.js', 'eslint.config.mjs'],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepack": "pnpm run build",
     "prepare": "ajs module imports install",
     "release": "pnpm run lint && pnpm run test && pnpm run prepack && release-it",
-    "test": "echo \"No test specified\""
+    "test": "ajs module test ."
   },
   "antelopeJs": {
     "exportsPath": "dist/interfaces",
@@ -43,6 +43,10 @@
     "importsOptional": [],
     "defaultConfig": {
       "url": "redis://localhost:6379"
+    },
+    "test": {
+      "project": "src/test/test-project-loader.js",
+      "folder": "dist/test"
     }
   },
   "dependencies": {
@@ -50,17 +54,22 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
-    "rimraf": "^6.0.1",
     "@eslint/js": "^9.25.0",
+    "chai": "^4.5.0",
+    "@types/chai": "^4.3.20",
+    "@types/ioredis-mock": "^8.2.6",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^22.14.1",
     "eslint": "^9.25.0",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.2.6",
     "globals": "^16.0.0",
+    "ioredis-mock": "^8.13.1",
     "prettier": "^3.5.3",
     "release-it": "^19.0.2",
     "release-it-changelogen": "^0.1.0",
+    "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.30.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,21 @@ importers:
       '@eslint/js':
         specifier: ^9.25.0
         version: 9.25.1
+      '@types/chai':
+        specifier: ^4.3.20
+        version: 4.3.20
+      '@types/ioredis-mock':
+        specifier: ^8.2.6
+        version: 8.2.6(ioredis@5.9.2)
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
+      chai:
+        specifier: ^4.5.0
+        version: 4.5.0
       eslint:
         specifier: ^9.25.0
         version: 9.25.1(jiti@2.5.1)
@@ -36,6 +48,9 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.0.0
+      ioredis-mock:
+        specifier: ^8.13.1
+        version: 8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.9.2))(ioredis@5.9.2)
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -44,7 +59,7 @@ importers:
         version: 19.0.2(@types/node@22.14.1)
       release-it-changelogen:
         specifier: ^0.1.0
-        version: 0.1.0(changelogen@0.5.7)(release-it@19.0.2(@types/node@22.14.1))(semver@7.7.1)
+        version: 0.1.0(changelogen@0.5.7)(release-it@19.0.2(@types/node@22.14.1))(semver@7.7.4)
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -248,6 +263,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/as-callback@3.0.0':
+    resolution: {integrity: sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==}
+
   '@ioredis/commands@1.5.0':
     resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
@@ -346,14 +364,25 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@types/chai@4.3.20':
+    resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/ioredis-mock@8.2.6':
+    resolution: {integrity: sha512-5heqtZMvQ4nXARY0o8rc8cjkJjct2ScM12yCJ/h731S9He93a2cv+kAhwPCNwTKDfNH9gjRfLG4VpAEYJU0/gQ==}
+    peerDependencies:
+      ioredis: '>=5'
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
   '@types/node@20.17.32':
     resolution: {integrity: sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==}
@@ -481,6 +510,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -556,6 +588,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -570,6 +606,9 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -668,6 +707,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -907,6 +950,14 @@ packages:
       picomatch:
         optional: true
 
+  fengari-interop@0.1.4:
+    resolution: {integrity: sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==}
+    peerDependencies:
+      fengari: ^0.1.0
+
+  fengari@0.1.5:
+    resolution: {integrity: sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -952,6 +1003,9 @@ packages:
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1085,6 +1139,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ioredis-mock@8.13.1:
+    resolution: {integrity: sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==}
+    engines: {node: '>=12.22'}
+    peerDependencies:
+      '@types/ioredis-mock': ^8
+      ioredis: ^5
 
   ioredis@5.9.2:
     resolution: {integrity: sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==}
@@ -1318,6 +1379,9 @@ packages:
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   lru-cache@11.2.4:
     resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
@@ -1566,6 +1630,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -1632,6 +1699,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readline-sync@1.4.10:
+    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
+    engines: {node: '>= 0.8.0'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -1726,6 +1797,11 @@ packages:
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1869,6 +1945,10 @@ packages:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1888,6 +1968,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -2183,6 +2267,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
 
+  '@ioredis/as-callback@3.0.0': {}
+
   '@ioredis/commands@1.5.0': {}
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -2283,11 +2369,19 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
+  '@types/chai@4.3.20': {}
+
   '@types/estree@1.0.7': {}
+
+  '@types/ioredis-mock@8.2.6(ioredis@5.9.2)':
+    dependencies:
+      ioredis: 5.9.2
 
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mocha@10.0.10': {}
 
   '@types/node@20.17.32':
     dependencies:
@@ -2462,6 +2556,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@1.1.0: {}
+
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
@@ -2550,6 +2646,16 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -2570,13 +2676,17 @@ snapshots:
       pathe: 1.1.2
       pkg-types: 1.3.1
       scule: 1.3.0
-      semver: 7.7.1
+      semver: 7.7.4
       std-env: 3.10.0
       yaml: 2.8.1
     transitivePeerDependencies:
       - magicast
 
   chardet@0.7.0: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   chokidar@3.6.0:
     dependencies:
@@ -2663,6 +2773,10 @@ snapshots:
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
+
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
 
   deep-is@0.1.4: {}
 
@@ -2983,6 +3097,16 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fengari-interop@0.1.4(fengari@0.1.5):
+    dependencies:
+      fengari: 0.1.5
+
+  fengari@0.1.5:
+    dependencies:
+      readline-sync: 1.4.10
+      sprintf-js: 1.1.3
+      tmp: 0.2.5
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3028,6 +3152,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   get-east-asian-width@1.3.0: {}
+
+  get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -3186,6 +3312,16 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.9.2))(ioredis@5.9.2):
+    dependencies:
+      '@ioredis/as-callback': 3.0.0
+      '@ioredis/commands': 1.5.0
+      '@types/ioredis-mock': 8.2.6(ioredis@5.9.2)
+      fengari: 0.1.5
+      fengari-interop: 0.1.4(fengari@0.1.5)
+      ioredis: 5.9.2
+      semver: 7.7.4
 
   ioredis@5.9.2:
     dependencies:
@@ -3411,6 +3547,10 @@ snapshots:
     dependencies:
       chalk: 5.4.1
       is-unicode-supported: 1.3.0
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
 
   lru-cache@11.2.4: {}
 
@@ -3666,6 +3806,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@1.1.1: {}
+
   perfect-debounce@1.0.0: {}
 
   picomatch@2.3.1: {}
@@ -3728,6 +3870,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  readline-sync@1.4.10: {}
+
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
@@ -3754,7 +3898,7 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  release-it-changelogen@0.1.0(changelogen@0.5.7)(release-it@19.0.2(@types/node@22.14.1))(semver@7.7.1):
+  release-it-changelogen@0.1.0(changelogen@0.5.7)(release-it@19.0.2(@types/node@22.14.1))(semver@7.7.4):
     dependencies:
       chalk: 5.4.1
       changelogen: 0.5.7
@@ -3763,7 +3907,7 @@ snapshots:
       execa: 8.0.1
       pathe: 1.1.2
       release-it: 19.0.2(@types/node@22.14.1)
-      semver: 7.7.1
+      semver: 7.7.4
       yargs-parser: 21.1.1
 
   release-it@19.0.2(@types/node@22.14.1):
@@ -3858,6 +4002,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.1: {}
+
+  semver@7.7.4: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -4025,6 +4171,8 @@ snapshots:
     dependencies:
       os-tmpdir: 1.0.2
 
+  tmp@0.2.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -4045,6 +4193,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.1.0: {}
 
   type-fest@0.21.3: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import Redis, { RedisOptions } from 'ioredis';
 
 export interface RedisConfig extends RedisOptions {
   url?: string;
+  useMock?: boolean;
 }
 
 let redisConfig: RedisConfig;
@@ -13,8 +14,8 @@ export function construct(config: RedisConfig): void {
 export function destroy(): void {}
 
 export async function start(): Promise<void> {
-  const client = createRedisClient(redisConfig);
-  if (redisConfig.lazyConnect) {
+  const client = await createRedisClient(redisConfig);
+  if (redisConfig.useMock || redisConfig.lazyConnect) {
     await client.connect();
   }
   internal.SetClient(client);
@@ -26,8 +27,13 @@ export async function stop(): Promise<void> {
   void internal.UnsetClient();
 }
 
-function createRedisClient(config: RedisConfig): Redis {
-  const { url, ...options } = config;
+async function createRedisClient(config: RedisConfig): Promise<Redis> {
+  if (config.useMock) {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    const { default: RedisMock } = await import('ioredis-mock');
+    return new RedisMock({ lazyConnect: true }) as unknown as Redis;
+  }
+  const { url, useMock: _, ...options } = config;
   if (!url) {
     return new Redis(options);
   }

--- a/src/test/interfaces/redis/beta/index.test.ts
+++ b/src/test/interfaces/redis/beta/index.test.ts
@@ -1,0 +1,169 @@
+import { expect } from 'chai';
+import { GetClient } from '@ajs.local/redis/beta';
+
+describe('Redis Interface - GetClient', () => {
+  it('should return a functional Redis client', async () => GetClientTest());
+});
+
+describe('Redis Interface - Key/Value Operations', () => {
+  it('should set and get a value', async () => SetGetTest());
+  it('should delete a key', async () => DelTest());
+  it('should return null for non-existent key', async () => GetNonExistentTest());
+});
+
+describe('Redis Interface - Hash Operations', () => {
+  it('should set and get hash fields', async () => HSetHGetTest());
+  it('should get all hash fields', async () => HGetAllTest());
+  it('should delete a hash field', async () => HDelTest());
+});
+
+describe('Redis Interface - List Operations', () => {
+  it('should push and pop from list', async () => ListPushPopTest());
+  it('should get a range of list elements', async () => LRangeTest());
+});
+
+describe('Redis Interface - Sorted Set Operations', () => {
+  it('should add and retrieve sorted set members', async () => ZAddZRangeTest());
+  it('should get score of a member', async () => ZScoreTest());
+  it('should remove a member', async () => ZRemTest());
+});
+
+describe('Redis Interface - Expiration', () => {
+  it('should set expiration and check TTL', async () => ExpireTTLTest());
+});
+
+describe('Redis Interface - Pub/Sub', () => {
+  it('should publish and receive messages', async () => PubSubTest());
+});
+
+async function GetClientTest() {
+  const client = await GetClient();
+  expect(client.set).to.be.a('function');
+  expect(client.get).to.be.a('function');
+  expect(client.del).to.be.a('function');
+  expect(client.duplicate).to.be.a('function');
+}
+
+async function SetGetTest() {
+  const client = await GetClient();
+  await client.set('test:key', 'hello');
+  const value = await client.get('test:key');
+  expect(value).to.equal('hello');
+  await client.del('test:key');
+}
+
+async function DelTest() {
+  const client = await GetClient();
+  await client.set('test:del', 'value');
+  const deleted = await client.del('test:del');
+  expect(deleted).to.equal(1);
+  const value = await client.get('test:del');
+  expect(value).to.equal(null);
+}
+
+async function GetNonExistentTest() {
+  const client = await GetClient();
+  const value = await client.get('test:nonexistent');
+  expect(value).to.equal(null);
+}
+
+async function HSetHGetTest() {
+  const client = await GetClient();
+  await client.hset('test:hash', 'field1', 'value1');
+  const value = await client.hget('test:hash', 'field1');
+  expect(value).to.equal('value1');
+  await client.del('test:hash');
+}
+
+async function HGetAllTest() {
+  const client = await GetClient();
+  await client.hset('test:hash:all', 'name', 'Alice');
+  await client.hset('test:hash:all', 'age', '30');
+  const all = await client.hgetall('test:hash:all');
+  expect(all).to.deep.equal({ name: 'Alice', age: '30' });
+  await client.del('test:hash:all');
+}
+
+async function HDelTest() {
+  const client = await GetClient();
+  await client.hset('test:hash:del', 'field', 'value');
+  await client.hdel('test:hash:del', 'field');
+  const value = await client.hget('test:hash:del', 'field');
+  expect(value).to.equal(null);
+  await client.del('test:hash:del');
+}
+
+async function ListPushPopTest() {
+  const client = await GetClient();
+  await client.lpush('test:list', 'a');
+  await client.rpush('test:list', 'b');
+  const left = await client.lpop('test:list');
+  const right = await client.rpop('test:list');
+  expect(left).to.equal('a');
+  expect(right).to.equal('b');
+}
+
+async function LRangeTest() {
+  const client = await GetClient();
+  await client.rpush('test:list:range', 'a', 'b', 'c');
+  const range = await client.lrange('test:list:range', 0, -1);
+  expect(range).to.deep.equal(['a', 'b', 'c']);
+  await client.del('test:list:range');
+}
+
+async function ZAddZRangeTest() {
+  const client = await GetClient();
+  await client.zadd('test:zset', 1, 'a');
+  await client.zadd('test:zset', 2, 'b');
+  await client.zadd('test:zset', 3, 'c');
+  const members = await client.zrange('test:zset', 0, -1);
+  expect(members).to.deep.equal(['a', 'b', 'c']);
+  await client.del('test:zset');
+}
+
+async function ZScoreTest() {
+  const client = await GetClient();
+  await client.zadd('test:zset:score', 42, 'member');
+  const score = await client.zscore('test:zset:score', 'member');
+  expect(Number(score)).to.equal(42);
+  await client.del('test:zset:score');
+}
+
+async function ZRemTest() {
+  const client = await GetClient();
+  await client.zadd('test:zset:rem', 1, 'a');
+  await client.zadd('test:zset:rem', 2, 'b');
+  await client.zrem('test:zset:rem', 'a');
+  const members = await client.zrange('test:zset:rem', 0, -1);
+  expect(members).to.deep.equal(['b']);
+  await client.del('test:zset:rem');
+}
+
+async function ExpireTTLTest() {
+  const client = await GetClient();
+  await client.set('test:expire', 'temp');
+  await client.expire('test:expire', 10);
+  const ttl = await client.ttl('test:expire');
+  expect(ttl).to.be.greaterThan(0);
+  expect(ttl).to.be.at.most(10);
+  await client.del('test:expire');
+}
+
+async function PubSubTest() {
+  const client = await GetClient();
+  const subscriber = client.duplicate();
+
+  const received: string[] = [];
+  await subscriber.subscribe('test:channel');
+  subscriber.on('message', (_channel: string, message: string) => {
+    received.push(message);
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  await client.publish('test:channel', 'hello');
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  expect(received).to.deep.equal(['hello']);
+  await subscriber.unsubscribe('test:channel');
+  await subscriber.quit();
+}

--- a/src/test/interfaces/redis_scheduler/beta.test.ts
+++ b/src/test/interfaces/redis_scheduler/beta.test.ts
@@ -1,0 +1,177 @@
+import { expect } from 'chai';
+import { GetClient } from '@ajs.local/redis/beta';
+import {
+  setHandler,
+  addTask,
+  removeTask,
+  enableListener,
+  disableListener,
+  runTasks,
+} from '@ajs.local/redis_scheduler/beta';
+
+const RedisKey = 'SchedulerUtil.Tasks';
+
+async function cleanupRedis() {
+  const client = await GetClient();
+  await client.del(RedisKey);
+}
+
+describe('Redis Scheduler - setHandler', () => {
+  it('should register a handler', async () => RegisterHandlerTest());
+  it('should reject handler names containing :', async () => RejectColonInNameTest());
+});
+
+describe('Redis Scheduler - addTask', () => {
+  it('should add a task to the sorted set', async () => AddTaskTest());
+  it('should throw for unknown handler', async () => AddTaskUnknownHandlerTest());
+});
+
+describe('Redis Scheduler - removeTask', () => {
+  it('should remove a task from the sorted set', async () => RemoveTaskTest());
+  it('should throw for unknown handler', async () => RemoveTaskUnknownHandlerTest());
+});
+
+describe('Redis Scheduler - enableListener / disableListener', () => {
+  it('should enable and disable the listener', async () => EnableDisableListenerTest());
+});
+
+describe('Redis Scheduler - runTasks', () => {
+  it('should execute due tasks', async () => RunDueTasksTest());
+  it('should not execute future tasks', async () => SkipFutureTasksTest());
+});
+
+describe('Redis Scheduler - retry logic', () => {
+  it('should retry failed tasks up to 3 times', async () => RetryFailedTasksTest());
+});
+
+async function RegisterHandlerTest() {
+  let called = false;
+  setHandler('test-register', () => {
+    called = true;
+  });
+  expect(called).to.equal(false);
+}
+
+async function RejectColonInNameTest() {
+  try {
+    setHandler('invalid:name', () => {});
+    expect.fail('should have thrown');
+  } catch (err) {
+    expect((err as Error).message).to.include('may not contain');
+  }
+}
+
+async function AddTaskTest() {
+  await cleanupRedis();
+  setHandler('test-add', () => {});
+
+  const dueTime = Date.now() + 60000;
+  await addTask('test-add', dueTime, 'task-data');
+
+  const client = await GetClient();
+  const members = await client.zrange(RedisKey, 0, -1);
+  expect(members).to.include('test-add:task-data');
+
+  await cleanupRedis();
+}
+
+async function AddTaskUnknownHandlerTest() {
+  try {
+    await addTask('nonexistent-handler', Date.now(), 'data');
+    expect.fail('should have thrown');
+  } catch (err) {
+    expect((err as Error).message).to.include('Unknown SchedulerUtil handler');
+  }
+}
+
+async function RemoveTaskTest() {
+  await cleanupRedis();
+  setHandler('test-remove', () => {});
+
+  const client = await GetClient();
+  await client.zadd(RedisKey, Date.now() + 60000, 'test-remove:remove-data');
+
+  await removeTask('test-remove', 'remove-data');
+
+  const members = await client.zrange(RedisKey, 0, -1);
+  expect(members).to.not.include('test-remove:remove-data');
+
+  await cleanupRedis();
+}
+
+async function RemoveTaskUnknownHandlerTest() {
+  try {
+    await removeTask('nonexistent-handler', 'data');
+    expect.fail('should have thrown');
+  } catch (err) {
+    expect((err as Error).message).to.include('Unknown SchedulerUtil handler');
+  }
+}
+
+async function EnableDisableListenerTest() {
+  await enableListener();
+  await disableListener();
+}
+
+async function RunDueTasksTest() {
+  await cleanupRedis();
+  const results: string[] = [];
+  setHandler('test-run', (taskInfo: string) => {
+    results.push(taskInfo);
+  });
+
+  const client = await GetClient();
+  await client.zadd(RedisKey, Date.now() - 1000, 'test-run:payload1');
+  await client.zadd(RedisKey, Date.now() - 500, 'test-run:payload2');
+
+  await runTasks();
+
+  expect(results).to.include('payload1');
+  expect(results).to.include('payload2');
+
+  const remaining = await client.zrange(RedisKey, 0, -1);
+  expect(remaining).to.have.length(0);
+
+  await cleanupRedis();
+}
+
+async function SkipFutureTasksTest() {
+  await cleanupRedis();
+  const results: string[] = [];
+  setHandler('test-future', (taskInfo: string) => {
+    results.push(taskInfo);
+  });
+
+  const client = await GetClient();
+  await client.zadd(RedisKey, Date.now() + 60000, 'test-future:future-data');
+
+  await runTasks();
+
+  expect(results).to.have.length(0);
+
+  const remaining = await client.zrange(RedisKey, 0, -1);
+  expect(remaining).to.have.length(1);
+
+  await cleanupRedis();
+}
+
+async function RetryFailedTasksTest() {
+  await cleanupRedis();
+  let callCount = 0;
+  setHandler('test-retry', () => {
+    callCount++;
+    throw new Error('intentional failure');
+  });
+
+  const client = await GetClient();
+  await client.zadd(RedisKey, Date.now() - 1000, 'test-retry:retry-data');
+
+  await runTasks();
+  expect(callCount).to.equal(1);
+
+  const retryMembers = await client.zrange(RedisKey, 0, -1);
+  expect(retryMembers).to.have.length(1);
+  expect(retryMembers[0]).to.match(/^RETRY-1:test-retry:retry-data$/);
+
+  await cleanupRedis();
+}

--- a/src/test/test-project-loader.js
+++ b/src/test/test-project-loader.js
@@ -1,0 +1,16 @@
+module.exports.setup = async () => ({
+  cacheFolder: '.antelope/cache',
+  modules: {
+    local: {
+      source: {
+        type: 'local',
+        path: '.',
+      },
+      config: {
+        useMock: true,
+      },
+    },
+  },
+});
+
+module.exports.cleanup = async () => {};


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add comprehensive test suites for both exported interfaces (`redis/beta` and `redis_scheduler/beta`) using `ioredis-mock` for in-memory testing.

- Add `useMock` config option to `RedisConfig` with dynamic import of `ioredis-mock` (no production overhead)
- **redis/beta** (14 tests): GetClient, key/value ops, hash ops, list ops, sorted set ops, expiration/TTL, pub/sub
- **redis_scheduler/beta** (10 tests): setHandler, addTask, removeTask, enableListener/disableListener, runTasks, retry logic
- Configure `test-project-loader.js` with `useMock: true` and wire up `ajs module test .` script

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds comprehensive test coverage for both `redis/beta` and `redis_scheduler/beta` interfaces using `ioredis-mock` for fast, in-memory testing without requiring a real Redis instance.

**Key changes:**
- Added `useMock` configuration option to `RedisConfig` with dynamic import (zero production overhead)
- Implemented 14 tests for `redis/beta`: GetClient validation, key/value operations, hash operations, list operations, sorted set operations, expiration/TTL handling, and pub/sub messaging
- Implemented 10 tests for `redis_scheduler/beta`: handler registration (including validation), task scheduling/removal, listener control, task execution, and retry logic
- Configured test infrastructure with `test-project-loader.js` and updated `package.json` to wire up `ajs module test .` command
- Added necessary test dependencies: `chai`, `ioredis-mock`, and corresponding type definitions

All tests are well-structured, properly clean up after themselves, and follow good testing practices. The implementation correctly handles the mock client initialization by ensuring `lazyConnect` is set and `connect()` is called.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The PR adds well-structured test infrastructure with comprehensive coverage, follows coding conventions (no comments, proper naming, functions under 40 lines), uses dynamic imports to avoid production overhead, and includes proper cleanup in tests. All changes are additive with no breaking modifications to existing code.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/index.ts | Added `useMock` config option with dynamic import for ioredis-mock, preventing production overhead |
| src/test/interfaces/redis/beta/index.test.ts | Comprehensive test suite for redis/beta interface with 14 tests covering key operations, hash, list, sorted sets, expiration, and pub/sub |
| src/test/interfaces/redis_scheduler/beta.test.ts | Complete test suite for redis_scheduler/beta with 10 tests covering handler registration, task operations, listener control, and retry logic |
| src/test/test-project-loader.js | Test project loader configuration enabling mock Redis client for in-memory testing |
| package.json | Added test dependencies (chai, ioredis-mock, types) and configured test script with antelopeJs test settings |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Loader as test-project-loader.js
    participant Index as src/index.ts
    participant Mock as ioredis-mock
    participant Interface as redis/beta Interface
    participant Scheduler as redis_scheduler/beta

    Test->>Loader: setup()
    Loader-->>Test: config with useMock: true

    Test->>Index: construct(config)
    Index->>Index: store redisConfig

    Test->>Index: start()
    Index->>Index: createRedisClient(config)
    alt useMock is true
        Index->>Mock: dynamic import('ioredis-mock')
        Mock-->>Index: RedisMock constructor
        Index->>Mock: new RedisMock({ lazyConnect: true })
        Mock-->>Index: mock client instance
    end
    Index->>Mock: client.connect()
    Index->>Interface: internal.SetClient(client)
    Interface-->>Index: client stored

    Test->>Interface: GetClient()
    Interface-->>Test: Redis client

    Test->>Test: Execute redis/beta tests
    Test->>Mock: set/get/del operations
    Test->>Mock: hash operations (hset/hget/hdel)
    Test->>Mock: list operations (lpush/rpush/lpop/rpop)
    Test->>Mock: sorted set operations (zadd/zrange/zscore)
    Test->>Mock: expiration (expire/ttl)
    Test->>Mock: pub/sub (subscribe/publish)

    Test->>Scheduler: setHandler(name, handler)
    Scheduler->>Scheduler: validate name (no ':')
    Scheduler->>Scheduler: store in handlers map

    Test->>Scheduler: addTask(handler, time, info)
    Scheduler->>Interface: GetClient()
    Interface-->>Scheduler: client
    Scheduler->>Mock: zadd(key, time, member)

    Test->>Scheduler: runTasks()
    Scheduler->>Mock: zrangebyscore(key, 0, now)
    Mock-->>Scheduler: due tasks
    Scheduler->>Mock: zrem(key, tasks)
    loop For each task
        Scheduler->>Scheduler: match task pattern
        Scheduler->>Scheduler: execute handler(taskInfo)
        alt handler throws error
            Scheduler->>Scheduler: check retry count
            alt retries < 3
                Scheduler->>Mock: zadd with RETRY prefix
            end
        end
    end

    Test->>Index: stop()
    Index->>Mock: client.quit()
    Index->>Interface: UnsetClient()

```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->