### PR TITLE
fix(redis_scheduler): use lazyConnect for listener duplicate client

### DIFF
--- a/src/interfaces/redis_scheduler/beta.ts
+++ b/src/interfaces/redis_scheduler/beta.ts
@@ -16,7 +16,6 @@ const MaxRetries = 3;
 const RetryDelayMs = 5000;
 const MaxTimerDelayMs = 86400000;
 const RetryPattern = /^(?:RETRY-(\d)+:)?([^:]*):(.*)$/;
-const RedisReadyStatus = 'ready';
 
 /** Map of registered task handlers by name */
 const handlers = new Map<string, HandlerType>();
@@ -88,10 +87,8 @@ function createTaskMember(handlerName: string, taskInfo: string): string {
  * ```
  */
 export async function enableListener() {
-  subscriber = (await GetClient()).duplicate();
-  if (subscriber.status !== RedisReadyStatus) {
-    await subscriber.connect();
-  }
+  subscriber = (await GetClient()).duplicate({ lazyConnect: true });
+  await subscriber.connect();
   await subscriber.subscribe(SchedulerChannel);
   subscriber.on('message', (channel, message) => {
     if (channel !== SchedulerChannel) {


### PR DESCRIPTION
### 🔗 Linked issue

- N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Update `enableListener()` to duplicate the Redis client with `{ lazyConnect: true }` and then connect explicitly.
- Remove the `subscriber.status` readiness guard that could race with the duplicate client's auto-connect behavior.
- Add a scheduler test that verifies `enableListener()` calls `duplicate()` with `lazyConnect: true`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

fixed race condition in scheduler listener by using explicit `lazyConnect: true` when duplicating Redis client

- removed `RedisReadyStatus` constant (no longer needed)
- simplified `enableListener()` to duplicate with `{ lazyConnect: true }` then connect explicitly
- removed status check that could race with auto-connect behavior
- added test coverage verifying the `lazyConnect` option is passed correctly

<h3>Confidence Score: 5/5</h3>

- safe to merge - eliminates race condition with clean solution
- the fix properly addresses a connection race condition by using explicit `lazyConnect: true` and removing the racy status check. The solution is well-tested and aligns with existing patterns in the codebase (see `src/index.ts:18-20`). Changes are minimal, focused, and backwards-compatible.
- no files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/interfaces/redis_scheduler/beta.ts | simplified connection logic by using `lazyConnect: true` and explicit connect, removing race condition guard |
| src/test/interfaces/redis_scheduler/beta.test.ts | added test verifying `enableListener()` uses `lazyConnect: true` when duplicating client |

</details>


</details>


<sub>Last reviewed commit: 1ffaddb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->