### PR TITLE
chore(deps): bump antelope interface dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "test": "src/test/antelope.test.ts"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.2",
-    "@antelopejs/interface-redis": "^0.0.2",
-    "@antelopejs/interface-redis-scheduler": "^0.0.2",
+    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-redis": "^0.0.6",
+    "@antelopejs/interface-redis-scheduler": "^0.0.6",
     "ioredis": "^5.10.1",
     "ioredis-mock": "^8.13.1"
   },

--- a/playground/package.json
+++ b/playground/package.json
@@ -7,7 +7,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.2"
+    "@antelopejs/interface-core": "^0.0.5"
   },
   "devDependencies": {
     "@types/node": "^20.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5
       '@antelopejs/interface-redis':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.6
+        version: 0.0.6(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-redis-scheduler':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.6
+        version: 0.0.6(@antelopejs/interface-core@0.0.5)(@antelopejs/interface-redis@0.0.6(@antelopejs/interface-core@0.0.5))
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -58,8 +58,8 @@ importers:
   playground:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5
     devDependencies:
       '@types/node':
         specifier: ^20.5.7
@@ -73,14 +73,19 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
-  '@antelopejs/interface-redis-scheduler@0.0.2':
-    resolution: {integrity: sha512-5Hdw3eCKNiwIoJD6iDe0SqwliuLsrApx1j/C3cn2JRP0giYoaT9ucfgqHv1OwkQ+mXiwvJfY4B3iEWKakzUj3Q==}
+  '@antelopejs/interface-redis-scheduler@0.0.6':
+    resolution: {integrity: sha512-d1bquTUgmtIJJP02OxSDhFVpudo9tSk2GJ0sQ0A/nXxOSAJlECmo0VYB+d+x2OCgjBCud2ksRVGEhZw7jujCJQ==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-redis': '>=0.0.5 <1.0.0'
 
-  '@antelopejs/interface-redis@0.0.2':
-    resolution: {integrity: sha512-BT4wtDG/xVqCrExcJUnMjBJRJdF2+t4GqkYB8r6vxU49hlZYW3cg8JBt7WL2n04ggBFi6znQg/B2YlVcZR+yuA==}
+  '@antelopejs/interface-redis@0.0.6':
+    resolution: {integrity: sha512-c9at7pIFO2UbFlL4EFJht8Wt8uir33oj1Ja1rxMgPLPO8x8bOk4s9//Bqaigrjc0ELj/5zZQkqx3fHdmNru5QQ==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1262,21 +1267,21 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-redis-scheduler@0.0.2':
+  '@antelopejs/interface-redis-scheduler@0.0.6(@antelopejs/interface-core@0.0.5)(@antelopejs/interface-redis@0.0.6(@antelopejs/interface-core@0.0.5))':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
-      '@antelopejs/interface-redis': 0.0.2
+      '@antelopejs/interface-core': 0.0.5
+      '@antelopejs/interface-redis': 0.0.6(@antelopejs/interface-core@0.0.5)
       ioredis: 5.10.1
     transitivePeerDependencies:
       - supports-color
 
-  '@antelopejs/interface-redis@0.0.2':
+  '@antelopejs/interface-redis@0.0.6(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
+      '@antelopejs/interface-core': 0.0.5
       ioredis: 5.10.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Bump `@antelopejs/interface-*` (and playground/config) to latest published versions. Interfaces stay in `dependencies`. Verified: install, build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the three `@antelopejs/interface-*` dependencies to their latest published versions and updates the pnpm lock file accordingly.

- `@antelopejs/interface-core` moves from `^0.0.2` to `^0.0.5` in both the root and playground packages.
- `@antelopejs/interface-redis` and `@antelopejs/interface-redis-scheduler` move from `^0.0.2` to `^0.0.6`; the new versions now declare explicit peer dependencies (`interface-core >=0.0.3 <1.0.0` and `interface-redis >=0.0.5 <1.0.0`) which are fully satisfied by the workspace's own `dependencies` entries as reflected in the lock file snapshots.

<h3>Confidence Score: 5/5</h3>

Routine dependency bump with no source code changes; all peer dependency constraints introduced in the new versions are correctly satisfied by the workspace.

Only package.json, playground/package.json, and pnpm-lock.yaml are touched. The new package versions introduce explicit peer dependency declarations, and the lock file snapshots confirm they are fully resolved to compatible installed versions. No application logic is changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps all three @antelopejs/interface-* dependencies: interface-core 0.0.2→0.0.5, interface-redis 0.0.2→0.0.6, interface-redis-scheduler 0.0.2→0.0.6 |
| playground/package.json | Aligns playground's @antelopejs/interface-core specifier to match the root (^0.0.2→^0.0.5) |
| pnpm-lock.yaml | Lock file updated with new resolved versions and integrity hashes; interface-redis and interface-redis-scheduler now correctly declare peer dependencies satisfied by the workspace's own deps |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json] -->|bumped| B[interface-core v0.0.5]
    A -->|bumped| C[interface-redis v0.0.6]
    A -->|bumped| D[interface-redis-scheduler v0.0.6]
    C -->|peerDep satisfied| B
    D -->|peerDep satisfied| B
    D -->|peerDep satisfied| C
    B --> E[pnpm-lock.yaml updated]
    C --> E
    D --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[package.json] -->|bumped| B[interface-core v0.0.5]
    A -->|bumped| C[interface-redis v0.0.6]
    A -->|bumped| D[interface-redis-scheduler v0.0.6]
    C -->|peerDep satisfied| B
    D -->|peerDep satisfied| B
    D -->|peerDep satisfied| C
    B --> E[pnpm-lock.yaml updated]
    C --> E
    D --> E
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump antelope interface dep..."](https://github.com/antelopejs/redis/commit/1e45776c2c4bb8c4096354d0f00386877727d0b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37904861)</sub>

<!-- /greptile_comment -->